### PR TITLE
Allow for rich content in tooltips

### DIFF
--- a/cms/static/sass/_base.scss
+++ b/cms/static/sass/_base.scss
@@ -595,26 +595,26 @@ hr.divide {
 
 .tooltip {
   @include transition(opacity $tmg-f3 ease-out 0s);
-  @include font-size(12);
-  @extend %t-regular;
   @extend %ui-depth5;
   position: absolute;
-  top: 0;
-  left: 0;
-  padding: 0 10px;
-  border-radius: 3px;
-  background: rgba(0, 0, 0, 0.85);
-  line-height: 26px;
-  color: $white;
-  pointer-events: none;
   opacity: 0.0;
+  transform: translateY(-100%);
 
-  &:after {
+  > .tooltip-content {
+    @include font-size(12);
+    @extend %t-regular;
+    max-width: 800px;
+    padding: 0 10px;
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.85);
+    line-height: 26px;
+    color: $white;
+  }
+
+  > .tooltip-arrow {
     @include font-size(20);
-    content: '▾';
-    display: block;
     position: absolute;
-    bottom: -14px;
+    bottom: -12px;
     left: 50%;
     margin-left: -7px;
     color: rgba(0, 0, 0, 0.85);

--- a/common/static/js/spec/tooltip_manager_spec.js
+++ b/common/static/js/spec/tooltip_manager_spec.js
@@ -32,10 +32,7 @@ describe('TooltipManager', function () {
     });
 
     showTooltip = function (element) {
-        element.trigger($.Event("mouseover", {
-            pageX: PAGE_X,
-            pageY: PAGE_Y
-        }));
+        element.trigger('mouseenter');
         jasmine.Clock.tick(500);
     };
 
@@ -51,54 +48,51 @@ describe('TooltipManager', function () {
     it('should be shown when mouse is over the element', function () {
         showTooltip(this.element);
         expect($('.tooltip')).toBeVisible();
-        expect($('.tooltip').text()).toBe('some text here.');
+        expect($('.tooltip-content').text()).toBe('some text here.');
     });
 
     it('should be hidden when mouse is out of the element', function () {
         showTooltip(this.element);
         expect($('.tooltip')).toBeVisible();
-        this.element.trigger($.Event("mouseout"));
-        jasmine.Clock.tick(50);
+        this.element.trigger('mouseleave');
+        jasmine.Clock.tick(500);
         expect($('.tooltip')).toBeHidden();
+    });
+
+    it('should stay visible when mouse is over the tooltip', function () {
+        showTooltip(this.element);
+        expect($('.tooltip')).toBeVisible();
+        this.element.trigger('mouseleave');
+        jasmine.Clock.tick(100);
+        this.tooltip.tooltip.trigger('mouseenter');
+        jasmine.Clock.tick(500);
+        expect($('.tooltip')).toBeVisible();
+        this.tooltip.tooltip.trigger('mouseleave');
+        jasmine.Clock.tick(500);
+        expect($('.tooltip')).toBeHidden();
+    });
+
+    it('should be shown when the element gets focus', function () {
+        this.element.trigger('focus');
+        jasmine.Clock.tick(500);
+        expect($('.tooltip')).toBeVisible();
     });
 
     it('should be hidden when user clicks on the element', function () {
         showTooltip(this.element);
         expect($('.tooltip')).toBeVisible();
-        this.element.trigger($.Event("click"));
-        jasmine.Clock.tick(50);
+        this.element.trigger('click');
         expect($('.tooltip')).toBeHidden();
     });
 
     it('can be configured to show when user clicks on the element', function () {
         this.element.attr('data-tooltip-show-on-click', true);
-        this.element.trigger($.Event("click"));
+        this.element.trigger('click');
         expect($('.tooltip')).toBeVisible();
     });
 
     it('can be be triggered manually', function () {
         this.tooltip.openTooltip(this.element);
         expect($('.tooltip')).toBeVisible();
-    });
-
-    it('should moves correctly', function () {
-        showTooltip(this.element);
-        expect($('.tooltip')).toBeVisible();
-        // PAGE_X - 0.5 * WIDTH
-        // 100 - 0.5 * 100 = 50
-        expect(parseInt($('.tooltip').css('left'))).toBe(50);
-        // PAGE_Y - (HEIGHT + 15)
-        // 100 - (100 + 15) = -15
-        expect(parseInt($('.tooltip').css('top'))).toBe(-15);
-        this.element.trigger($.Event("mousemove", {
-            pageX: PAGE_X + DELTA,
-            pageY: PAGE_Y + DELTA
-        }));
-        // PAGE_X + DELTA - 0.5 * WIDTH
-        // 100 + 10 - 0.5 * 100 = 60
-        expect(parseInt($('.tooltip').css('left'))).toBe(60);
-        // PAGE_Y + DELTA - (HEIGHT + 15)
-        // 100 + 10 - (100 + 15) = -5
-        expect(parseInt($('.tooltip').css('top'))).toBe(-5);
     });
 });

--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -138,7 +138,7 @@ def enable_jquery_animations(page):
 
 def disable_css_animations(page):
     """
-    Disable CSS3 animations, transitions, transforms.
+    Disable CSS3 animations and transitions.
     """
     page.browser.execute_script("""
         var id = 'no-transitions';
@@ -160,11 +160,6 @@ def disable_css_animations(page):
                     '-o-transition-property: none !important;',
                     '-ms-transition-property: none !important;',
                     'transition-property: none !important;',
-                    '-webkit-transform: none !important;',
-                    '-moz-transform: none !important;',
-                    '-o-transform: none !important;',
-                    '-ms-transform: none !important;',
-                    'transform: none !important;',
                     '-webkit-animation: none !important;',
                     '-moz-animation: none !important;',
                     '-o-animation: none !important;',
@@ -189,7 +184,7 @@ def disable_css_animations(page):
 
 def enable_css_animations(page):
     """
-    Enable CSS3 animations, transitions, transforms.
+    Enable CSS3 animations and transitions.
     """
     page.browser.execute_script("""
         var styles = document.getElementById('no-transitions'),

--- a/lms/static/sass/course/base/_base.scss
+++ b/lms/static/sass/course/base/_base.scss
@@ -129,30 +129,38 @@ img {
 }
 
 .tooltip {
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 99999;
-  padding: 0 10px;
-  border-radius: 3px;
-  background: rgba(0, 0, 0, .85);
-  font-size: 11px;
-  font-weight: 400;
-  line-height: 26px;
-  color: $white;
-  pointer-events: none;
-  opacity: 0;
   @include transition(opacity .1s linear 0s);
+  z-index: 99999;
+  position: absolute;
+  opacity: 0;
+  transform: translateY(-100%);
 
-  &:after {
-    content: '▾';
-    display: block;
+  > .tooltip-content {
+    font-size: 11px;
+    font-weight: 400;
+    max-width: 800px;
+    padding: 0 10px;
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.85);
+    line-height: 26px;
+    color: $white;
+
+    ul, ol {
+      margin: 0;
+    }
+
+    a {
+      color: $blue-l3;
+    }
+  }
+
+  > .tooltip-arrow {
+    font-size: 20px;
     position: absolute;
-    bottom: -14px;
+    bottom: -9px;
     left: 50%;
     margin-left: -7px;
-    font-size: 20px;
-    color: rgba(0, 0, 0, .85);
+    color: rgba(0, 0, 0, 0.85);
   }
 }
 

--- a/lms/static/sass/views/_decoupled-verification.scss
+++ b/lms/static/sass/views/_decoupled-verification.scss
@@ -195,25 +195,24 @@
 
     .tooltip {
         @include transition(opacity $tmg-f3 ease-out 0s);
-        @include font-size(12);
         position: absolute;
-        width: 350px;
-        top: 0;
-        left: 0;
-        padding: 10px 20px;
-        border-radius: 3px;
-        background: rgba(0, 0, 0, 0.85);
-        line-height: 26px;
-        color: $white;
-        pointer-events: none;
         opacity: 0.0;
+        transform: translateY(-100%);
 
-        &:after {
+        > .tooltip-content {
+            @include font-size(12);
+            width: 350px;
+            padding: 10px 20px;
+            border-radius: 3px;
+            background: rgba(0, 0, 0, 0.85);
+            line-height: 26px;
+            color: $white;
+        }
+
+        > .tooltip-arrow {
             @include font-size(20);
-            content: '▾';
-            display: block;
             position: absolute;
-            bottom: -14px;
+            bottom: -12px;
             left: 50%;
             margin-left: -7px;
             color: rgba(0, 0, 0, 0.85);


### PR DESCRIPTION
**Feature:** This pull request implements tooltips with rich content, including links.

**Implementation:** The current tooltip implementation has two limitations that prevent it from being used for rich content:
- Tooltips follow the mouse, so it is effectively impossible to click on any links in the tooltips
- If the content is too wide, tooltips can overflow off the left side of the viewport

This pull request solves these problems by:
- Making tooltips static relative to the position of the parent element
- Preventing tooltips from going past the left edge of the display

**Usage:** The same as the existing tooltips. add a `data-tooltip` attribute to any html element.

**Example:** See [this course](http://courses.behavioralinsightsteam.com/courses/course-v1:BIT+EWOKS101+2016/courseware/3238406bf179491b8d6464803d0f184b/61d5e06ec81541cfa3894c9cca02e526/)

**See also:** [upstream pull request](https://github.com/edx/edx-platform/pull/11854)
