### PR TITLE
When course mode doesn't require notification go straight do dashboard.

### DIFF
--- a/lms/static/js/commerce/views/receipt_view.js
+++ b/lms/static/js/commerce/views/receipt_view.js
@@ -27,6 +27,20 @@ var edx = edx || {};
             this.render();
         },
 
+        requiresVerification: function(product){
+            function getAttribute(attribute){
+                var attrs = product.attribute_values;
+                for(var idx=0; idx < attrs.length; idx++){
+                    var attr = attrs[idx];
+                    if (attr.name == attribute){
+                        return attr.value;
+                    }
+                }
+            }
+
+            return getAttribute("id_verification_required");
+        },
+
         renderReceipt: function (data) {
             var templateHtml = $("#receipt-tpl").html(),
                 context = {
@@ -35,12 +49,23 @@ var edx = edx || {};
                 },
                 providerId;
 
+            var requires_verification = false;
+
+            var _this = this;
+
+            _.each(data.lines, function (line) {
+               if (_this.requiresVerification(line.product)){
+                   requires_verification = true;
+               }
+            });
+
             // Add the receipt info to the template context
             this.courseKey = this.getOrderCourseKey(data);
             this.username = this.$el.data('username');
             _.extend(context, {
                 receipt: this.receiptContext(data),
-                courseKey: this.courseKey
+                courseKey: this.courseKey,
+                requires_verification: requires_verification
             });
 
             this.$el.html(_.template(templateHtml)(context));

--- a/lms/static/js/commerce/views/receipt_view.js
+++ b/lms/static/js/commerce/views/receipt_view.js
@@ -29,13 +29,8 @@ var edx = edx || {};
 
         requiresVerification: function(product){
             function getAttribute(attribute){
-                var attrs = product.attribute_values;
-                for(var idx=0; idx < attrs.length; idx++){
-                    var attr = attrs[idx];
-                    if (attr.name == attribute){
-                        return attr.value;
-                    }
-                }
+                var attr = _.findWhere(product.attribute_values, {name: attribute});
+                return attr && attr.value;
             }
 
             return getAttribute("id_verification_required");
@@ -49,16 +44,10 @@ var edx = edx || {};
                 },
                 providerId;
 
-            var requires_verification = false;
-
-            var _this = this;
-
-            _.each(data.lines, function (line) {
-               if (_this.requiresVerification(line.product)){
-                   requires_verification = true;
-               }
-            });
-
+            var requires_verification = _.any(data.lines, function (line) {
+                return this.requiresVerification(line.product);
+            }, this);
+            
             // Add the receipt info to the template context
             this.courseKey = this.getOrderCourseKey(data);
             this.username = this.$el.data('username');

--- a/lms/templates/commerce/receipt.underscore
+++ b/lms/templates/commerce/receipt.underscore
@@ -86,7 +86,7 @@
     <% } %>
 
     <nav class="nav-wizard is-ready">
-        <% if ( verified ) { %>
+        <% if ( verified || !requires_verification ) { %>
             <a class="next action-primary right" href="/dashboard"><%- gettext( "Go to Dashboard" ) %></a>
         <% } else { %>
           <a id="verify_later_button" class="next action-secondary verify-later nav-link" href="/dashboard" data-tooltip="<%- _.sprintf( gettext( "If you don't verify your identity now, you can still explore your course from your dashboard. You will receive periodic reminders from %(platformName)s to verify your identity." ), { platformName: platformName } ) %>">


### PR DESCRIPTION
Working fix for OC-1478. Testing instructions: 

Prepare the enviorment: 
1. Install devstack using instructions from here:  https://github.com/BehavioralInsightsTeam/ecommerce/pull/1
2. Create new course in Studio 
3. Start e-commerce and go to `localhost:8002/courses`, click add course, set Professional Education and leave "Identification required to off". 

Reproduce the issue: 
1. Register to the platform with a new user, and select your professional education course, pay for it in e-commerce. 
2. Observe that on Receipt page you get message asking you tu verify your identity: 

![selection_002](https://cloud.githubusercontent.com/assets/112872/15232199/ece56578-189f-11e6-97ec-83b461734dd6.png)

Verify the fix: 
1. Checkout this branch
2. Register to the platform with a new user, and select your professional education course, pay for it in e-commerce. 
3. Observe that on Receipt page you get a button redirecting you to dashboard: 

![selection_003](https://cloud.githubusercontent.com/assets/112872/15232213/fded2112-189f-11e6-8c15-d323c0089a28.png)
# Cat screenshot

![selection_001](https://cloud.githubusercontent.com/assets/112872/15231938/5ee6d69a-189e-11e6-9b92-534791052262.png)
